### PR TITLE
ci: Atualiza os actions da v2 para v3

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,10 +10,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.19.2
 


### PR DESCRIPTION
Node.js 12 actions (actions/checkout@v2, actions/setup-go@v2) estão depreciados. 
Este PR atualiza eles para a v3 que usa Node.js 16 na qual os actuais GitHub actions rodam.
Para mais informações 👉🏿  [GitHub Actions: All Actions will begin running on Node16 instead of Node12](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/)